### PR TITLE
Compute path for axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ module.exports = {
             responseHeaders: {
                 'Content-Type': 'application/json',
             },
+            baseURL: '/api/v1',
         },
     ],
 };
@@ -104,6 +105,7 @@ module.exports = {
 | `providers[].requestHeaders`   |    No    |      -       | Request headers shared across all requests                                                                                                                                                           |
 | `providers[].responseHeaders`  |    No    |      -       | Response headers shared across all responses                                                                                                                                                         |
 | `providers[].queryArrayFormat` |    No    | `"brackets"` | Sets separator for array in query - possible options are `"indices"`, `"brackets"`, `"comma"` and `"repeat"` [(source)](https://github.com/ljharb/qs#stringifying). The default value is `brackets`. |
+| `providers[].baseURL`          |    No    |     `""`     | Adds prefix to path shared across all requests                                                                                                                                                       |
 | `buildDir`                     |    No    |  `./pacts`   | Directory where generated pacts will be placed                                                                                                                                                       |
 | `verbose`                      |    No    |   `false`    | If set to `true` additional information during pacts generating process will be logged                                                                                                               |
 
@@ -136,6 +138,7 @@ module.exports = {
             queryArrayFormat: 'comma',
         },
     ],
+    baseURL: '/api/v1',
 };
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pact-gen-ts",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pact-gen-ts",
-            "version": "0.13.0",
+            "version": "0.14.0",
             "license": "MIT",
             "dependencies": {
                 "glob": "^7.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pact-gen-ts",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pact-gen-ts",
-            "version": "0.12.0",
+            "version": "0.13.0",
             "license": "MIT",
             "dependencies": {
                 "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pact-gen-ts",
-    "version": "0.13.0",
+    "version": "0.14.0",
     "description": "Generating pact files from typescript definitions",
     "keywords": [
         "pacts",

--- a/src/core/create-pact-example-object.ts
+++ b/src/core/create-pact-example-object.ts
@@ -2,7 +2,7 @@ import {createMapper} from '../utils/mapper';
 import {isLiteralObject} from '../utils/object-type';
 import {TypeRepresentation} from './type-representation';
 
-const exampleRepresentationOfType = createMapper<unknown, boolean | number | string>([
+export const exampleRepresentationOfType = createMapper<unknown, boolean | number | string>([
     ['boolean', true],
     ['number', 10],
     ['string', 'text'],

--- a/src/core/interaction-creator.ts
+++ b/src/core/interaction-creator.ts
@@ -83,6 +83,9 @@ export class InteractionCreator {
                 queryOfRequest = new Query(apiFunctionNode, this.sourceFile, this.provider.queryArrayFormat);
             }
 
+            if (this.provider.baseURL) {
+                newInteraction.request.path = this.provider.baseURL + (newInteraction.request.path || '');
+            }
             newInteraction.response.body = responseBody.body;
             newInteraction.response.matchingRules = responseBody.matchingRules;
             newInteraction.request.body = requestBody.body;

--- a/src/core/interaction-creator.ts
+++ b/src/core/interaction-creator.ts
@@ -73,6 +73,7 @@ export class InteractionCreator {
 
                 newInteraction.request.method = pactAxios.getRequestMethod();
 
+                newInteraction.request.path ||= pactAxios.getPath();
                 responseBody = new PactAxiosResponseBody(pactAxios, this.sourceFile);
                 requestBody = new PactAxiosRequestBody(pactAxios, this.sourceFile);
                 queryOfRequest = new PactAxiosQuery(pactAxios, this.sourceFile, this.provider.queryArrayFormat);

--- a/src/core/read-pacts-config.ts
+++ b/src/core/read-pacts-config.ts
@@ -13,6 +13,7 @@ interface CommonProviderConfig {
     requestHeaders?: Record<string, string>;
     responseHeaders?: Record<string, string>;
     queryArrayFormat?: IStringifyOptions['arrayFormat'];
+    baseURL?: string;
 }
 
 export interface ProviderConfig extends CommonProviderConfig {

--- a/tests/int/__snapshots__/pactGenerating.test.ts.snap
+++ b/tests/int/__snapshots__/pactGenerating.test.ts.snap
@@ -526,6 +526,143 @@ exports[`createPacts pact-axios 1`] = `
   },
   "interactions": [
     {
+      "description": "getPactAxiosSingleQuoteArgumentPathApiFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/clients",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
+      "description": "getPactAxiosDoubleQuoteArgumentPathApiFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/clients",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
+      "description": "getPactAxiosTemplateStringArgumentPathApiFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/clients",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
+      "description": "getPactAxiosArgumentPathFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/clients/10/posts",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
+      "description": "getPactAxiosTemplateStringPathFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/client/1/application/1",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosVariablePathFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/applications",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosVariableConcatPathFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/applications",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosVariableConcatPathWithVariableFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/text",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosVariableTemplateStringPathFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/client/1/application/1",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosConcatenatedPathFunction",
+      "request": {
+        "headers": {},
+        "method": "DELETE",
+        "path": "/api/client/1",
+      },
+      "response": {
+        "headers": {},
+        "status": 204,
+      },
+    },
+    {
+      "description": "getPactAxiosPathOverrideApiFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/api/override",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
       "description": "getPactAxiosApiFunction",
       "request": {
         "headers": {},

--- a/tests/int/__snapshots__/pactGenerating.test.ts.snap
+++ b/tests/int/__snapshots__/pactGenerating.test.ts.snap
@@ -82,6 +82,49 @@ exports[`createPacts axios 1`] = `
 }
 `;
 
+exports[`createPacts base-url 1`] = `
+{
+  "consumer": {
+    "name": "consumer-name",
+  },
+  "interactions": [
+    {
+      "description": "baseUrlConfigAxiosFunction",
+      "request": {
+        "headers": {},
+        "method": "GET",
+        "path": "/api/v1/clients",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+    {
+      "description": "baseUrlApiFunction",
+      "request": {
+        "headers": {},
+        "path": "/api/v1",
+      },
+      "response": {
+        "body": "text",
+        "headers": {},
+        "status": 200,
+      },
+    },
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0",
+    },
+  },
+  "provider": {
+    "name": "provider-name",
+  },
+}
+`;
+
 exports[`createPacts basic 1`] = `
 {
   "consumer": {

--- a/tests/int/pactGenerating.test.ts
+++ b/tests/int/pactGenerating.test.ts
@@ -26,6 +26,26 @@ describe('createPacts', () => {
         });
     });
 
+    test('base-url', () => {
+        const pactsConfig = {
+            consumer: 'consumer-name',
+            buildDir: 'pacts',
+            providers: [
+                {
+                    provider: 'provider-name',
+                    files: ['tests/int/testCases/base-url/**/*.ts'],
+                    baseURL: '/api/v1',
+                },
+            ],
+        };
+
+        const generatedPacts = createPacts(pactsConfig);
+
+        generatedPacts.forEach((pact) => {
+            expect(JSON.parse(JSON.stringify(pact, null, 2))).toMatchSnapshot();
+        });
+    });
+
     test.each<IStringifyOptions['arrayFormat']>(['brackets', 'indices', 'comma', 'repeat'])(
         'handles "%s" array format for query params',
         (queryArrayFormat) => {

--- a/tests/int/testCases/base-url/apiFunctions.ts
+++ b/tests/int/testCases/base-url/apiFunctions.ts
@@ -1,0 +1,23 @@
+import Axios from 'axios';
+
+export const axiosInstance = Axios.create({
+    /** This is an example where baseURL configuration option could be useful - same baseURL in custom axios instance
+     * and in pacts.config.js which is then used as a prefix for all paths in interactions**/
+    baseURL: 'api/v1',
+});
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export const baseUrlConfigAxiosFunction = async () => {
+    const {data} = await axiosInstance.get<string>('/clients');
+    return data;
+};
+
+/**
+ * @pact
+ */
+export function baseUrlApiFunction() {
+    return 'string';
+}

--- a/tests/int/testCases/pact-axios/apiFunctions.ts
+++ b/tests/int/testCases/pact-axios/apiFunctions.ts
@@ -1,6 +1,103 @@
 import axios, {AxiosInstance} from 'axios';
 import {axiosInstance} from './axios-instance';
 
+export const applicationId = '1';
+export const clientNo = '1';
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosSingleQuoteArgumentPathApiFunction() {
+    const {data} = await axios.get<string>('/clients');
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosDoubleQuoteArgumentPathApiFunction() {
+    const {data} = await axios.get<string>("/clients");
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosTemplateStringArgumentPathApiFunction() {
+    const {data} = await axios.get<string>(`/clients`);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export const getPactAxiosArgumentPathFunction = async (clientNumber: number) => {
+    const {data} = await axios.get<string>(`/clients/${clientNumber}/posts`);
+    return data;
+};
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosTemplateStringPathFunction() {
+    await axios.delete<void>(`/api/client/${clientNo}/application/${applicationId}`);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosVariablePathFunction() {
+    const endpointUrl = '/api/applications';
+    await axios.delete<void>(endpointUrl);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosVariableConcatPathFunction() {
+    const endpointUrl = '/api/' + 'applications';
+    await axios.delete<void>(endpointUrl);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosVariableConcatPathWithVariableFunction(param: string) {
+    const endpointUrl = '/api/' + param;
+    await axios.delete<void>(endpointUrl);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosVariableTemplateStringPathFunction() {
+    const endpointUrl = `/api/client/${clientNo}/application/${applicationId}`;
+    await axios.delete<void>(endpointUrl);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ */
+export async function getPactAxiosConcatenatedPathFunction() {
+    await axios.delete<void>('/api/client/' + clientNo);
+}
+
+/**
+ * @pact
+ * @pact-axios
+ * @pact-path /api/override
+ */
+export async function getPactAxiosPathOverrideApiFunction() {
+    const {data} = await axios.get<string>('/api');
+}
+
 /**
  * @pact
  * @pact-axios


### PR DESCRIPTION
Closes #67 

Additionaly this PR introduces baseURL which can be set in pacts.config.js. This option allows to set prefix path for all interactions.
It is heplful when you use baseURL from axios.