### PR TITLE
fix: Run husky on non-CI env only

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,6 @@
+// Skip Husky install in CI
+if (process.env.CI === 'true') {
+    process.exit(0);
+}
+const husky = (await import('husky')).default;
+husky();

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "build": "tsc -p tsconfig.json",
         "release": "semantic-release",
         "test": "jest",
-        "prepare": "husky"
+        "prepare": "node .husky/install.mjs"
     },
     "dependencies": {
         "glob": "^7.1.6",


### PR DESCRIPTION
Fixes releasing issue: https://github.com/HLTech/pact-gen-ts/actions/runs/9547349108/job/26312209350 

Solustion based on https://typicode.github.io/husky/how-to.html#ci-server-and-docker